### PR TITLE
cymem 2.0.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,18 +21,23 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
-    - cython
+    - cython >=0.25
     - pip
     - python
     - setuptools
     - wheel
-
   run:
     - python
 
 test:
   requires:
+    - pip
     - pytest
+  imports:
+    - cymem
+  commands:
+    - pip check
+    - python -m pytest --tb=native --pyargs cymem
 
 about:
   home: https://github.com/explosion/cymem
@@ -43,6 +48,8 @@ about:
     cymem provides two small memory-management helpers for Cython. They make it
     easy to tie memory to a Python object’s life-cycle, so that the memory is
     freed when the object is garbage collected.
+  dev_url: https://github.com/explosion/cymem
+  doc_url: https://github.com/explosion/cymem/blob/master/README.md
 extra:
   recipe-maintainers:
     - rmax

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "cymem" %}
-{% set version = "2.0.5" %}
-{% set sha256sum = "190e15d9cf2c3bde60ae37bddbae6568a36044dc4a326d84081a5fa08818eee0" %}
+{% set version = "2.0.6" %}
+{% set sha256sum = "169725b5816959d34de2545b33fee6a8021a6e08818794a426c5a4f981f17e5e" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,6 +42,7 @@ test:
 about:
   home: https://github.com/explosion/cymem
   license: MIT
+  license_family: MIT
   license_file: LICENSE
   summary: Manage calls to calloc/free through Cython
   description: |


### PR DESCRIPTION
Update cymem to 2.0.6

License: https://github.com/explosion/cymem/blob/v2.0.6/LICENSE
Requirements:
- https://github.com/explosion/cymem/blob/v2.0.6/pyproject.toml
- https://github.com/explosion/cymem/blob/v2.0.6/requirements.txt
- https://github.com/explosion/cymem/blob/v2.0.6/setup.py

Actions:
1. Add pinning for cython
2. Add pip check
3. Add pytest command
4. Add dev and doc urls
5. Add license_family